### PR TITLE
Add Spotlight behavior with Windows Start Menu

### DIFF
--- a/macos-keys-on-windows.ahk
+++ b/macos-keys-on-windows.ahk
@@ -111,3 +111,5 @@ $#+PgDn::{
 #HotIf
 
 $^!Space::Send("{LWin down}.{LWin up}") ; Emoji picker (Mac: Ctrl + Cmd + Space).
+
+$!Space::Send "^{Esc}" ; Spotlight thing


### PR DESCRIPTION
With this line we can use `ALT + Space` to get some similar Spotlight usage.